### PR TITLE
Make scss-lint not part of the default build, only run it on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ node_js:
 before_script:
   - gem install scss-lint
   - npm install -g gulp
-script: gulp
+script: gulp prod

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,3 +31,9 @@
         ```
         gulp --watch
         ```
+
+    1. Watch for changes and lint
+
+        ```
+        gulp prod --watch
+        ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,6 @@ var argv = require('minimist')(process.argv.slice(2));
 var concat = require('gulp-concat');
 var gulp = require('gulp');
 var gulpif = require('gulp-if');
-var scsslint = require('gulp-scss-lint');
 
 // Is the current build running on travis?
 var onTravis = !!process.env.TRAVIS;
@@ -54,6 +53,8 @@ gulp.task('css', function() {
  * Run the CSS Linter on the CSS files
  */
 gulp.task('css-lint', function() {
+  var scsslint = require('gulp-scss-lint');
+
   return gulp.src(paths.src.scss)
     .pipe(scsslint())
     // Only fail the build when running on Travis
@@ -113,4 +114,5 @@ if (argv.watch) {
   gulp.watch(paths.src.scss, ['css']);
 }
 
-gulp.task('default', ['build-clean', 'build', 'lint']);
+gulp.task('default', ['build-clean', 'build']);
+gulp.task('prod', ['build-clean', 'build', 'lint']);


### PR DESCRIPTION
@marcpechaitis - just run `gulp prod --watch` if you want to keep linting and watching at the same time.
