### PR TITLE
SISRP-9457 - Go back to CalCentral logo looks stretched on FF & IE

### DIFF
--- a/src/css/cs/items/_calcentralheader.scss
+++ b/src/css/cs/items/_calcentralheader.scss
@@ -13,7 +13,7 @@ $uc-calcentral-gold: #f1a91e;
 
     .uc-calcentral-logo {
       background: url('/uc_cust/data/portal/images/calcentral_logo_340x35.svg') no-repeat left center;
-      background-size: 200px 30px;
+      background-size: contain;
       border-bottom: 2px solid transparent;
       display: block;
       height: 35px;


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-9457
